### PR TITLE
add catch block to worker message handler, resolves #6

### DIFF
--- a/wrapper/src/index.ts
+++ b/wrapper/src/index.ts
@@ -8,12 +8,15 @@ function call(type: string, body: unknown): Promise<unknown> {
   const uid = Math.random().toString(36);
   worker.postMessage({ type, body, uid });
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handler = (e: any) => {
       if (e.data.uid === uid) {
         worker.removeEventListener("message", handler);
-        resolve(e.data.body);
+        if (e.data.type === 'error') {
+          return reject(e.data.body);
+        }
+        return resolve(e.data.body);
       }
     };
 

--- a/wrapper/src/worker.ts
+++ b/wrapper/src/worker.ts
@@ -108,5 +108,11 @@ ctx.addEventListener("message", (e) => {
       body,
       uid: data.uid,
     });
+  }).catch((err) => {
+    ctx.postMessage({
+      type: 'error',
+      body: err,
+      uid: data.uid,
+    });
   });
 });


### PR DESCRIPTION
This PR adds a catch block to the worker's message event handler.  If the `call()` receives this message, it rejects its promise and downstream code can detect it.